### PR TITLE
design single meme view, loading view, overlay menu and some refactoring

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,6 @@
     "react-router": "^4.3.1",
     "react-router-dom": "^4.3.1",
     "react-scripts": "2.1.8",
-    "react-share": "^2.4.0",
     "redux": "^4.0.1",
     "redux-thunk": "^2.3.0",
     "socket.io-client": "^2.2.0",

--- a/src/actions/auth.js
+++ b/src/actions/auth.js
@@ -1,4 +1,4 @@
-import { USER_LOGGED_IN, LOG_OUT } from 'shared/constants/actionTypes';
+import { USER_LOGGED_IN, LOG_OUT } from 'constants/actionTypes';
 
 export const login = user => {
   return {

--- a/src/actions/auth.test.js
+++ b/src/actions/auth.test.js
@@ -1,6 +1,6 @@
 // Modules
 import { login, logout } from 'actions/auth';
-import { USER_LOGGED_IN, LOG_OUT } from 'shared/constants/actionTypes';
+import { USER_LOGGED_IN, LOG_OUT } from 'constants/actionTypes';
 
 describe('auth', () => {
   it('returns login action', async () => {

--- a/src/actions/image.js
+++ b/src/actions/image.js
@@ -1,4 +1,4 @@
-import { REMOVE_IMAGE, SELECT_IMAGE } from 'shared/constants/actionTypes';
+import { REMOVE_IMAGE, SELECT_IMAGE } from 'constants/actionTypes';
 
 export const selectImage = imageUrl => {
   return {

--- a/src/actions/image.test.js
+++ b/src/actions/image.test.js
@@ -1,6 +1,6 @@
 // Modules
 import { selectImage, removeImage } from 'actions/image';
-import { REMOVE_IMAGE, SELECT_IMAGE } from 'shared/constants/actionTypes';
+import { REMOVE_IMAGE, SELECT_IMAGE } from 'constants/actionTypes';
 
 describe('image action', () => {
   it('returns selectImage action', async () => {

--- a/src/actions/loading.js
+++ b/src/actions/loading.js
@@ -1,0 +1,9 @@
+import { IS_COMPLETE, IS_LOADING } from 'constants/actionTypes';
+
+export const startLoader = () => {
+  return { type: IS_LOADING };
+};
+
+export const stopLoader = () => {
+  return { type: IS_COMPLETE };
+};

--- a/src/actions/menu.js
+++ b/src/actions/menu.js
@@ -1,0 +1,10 @@
+import { TOGGLE_MENU } from 'constants/actionTypes';
+
+const toggleMenu = status => {
+  return {
+    type: TOGGLE_MENU,
+    status,
+  };
+};
+
+export default toggleMenu;

--- a/src/actions/modal.js
+++ b/src/actions/modal.js
@@ -1,4 +1,4 @@
-import { HIDE_MODAL, SHOW_MODAL } from 'shared/constants/actionTypes';
+import { HIDE_MODAL, SHOW_MODAL } from 'constants/actionTypes';
 
 export const showModal = id => {
   return {

--- a/src/actions/modal.test.js
+++ b/src/actions/modal.test.js
@@ -1,6 +1,6 @@
 // Modules
 import { showModal, hideModal } from 'actions/modal';
-import { SHOW_MODAL, HIDE_MODAL } from 'shared/constants/actionTypes';
+import { SHOW_MODAL, HIDE_MODAL } from 'constants/actionTypes';
 
 describe('modal action', () => {
   it('returns showModal action', async () => {

--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -10,16 +10,20 @@ import { calculateRem, mobileWidth } from 'styles';
 import { ShareButton, Discover, Ellipsis, Create } from 'components/Icons';
 import { white } from 'styles/colors';
 import { showModal } from 'actions/modal';
+import toggleMenu from 'actions/menu';
 
 export class Header extends Component {
-  static propTypes = {};
-
   share = () => {
     const { isLoggedIn, actions } = this.props;
     if (!isLoggedIn) {
       return actions.showModal('auth');
     }
     return actions.showModal('share');
+  };
+
+  toggleMenu = () => {
+    const { actions, menuStatus } = this.props;
+    return actions.toggleMenu(!menuStatus);
   };
 
   render() {
@@ -42,7 +46,7 @@ export class Header extends Component {
         </NavLeft>
         <NavRight>
           <NavItem last>
-            <Ellipsis />
+            <Ellipsis onClick={this.toggleMenu} />
           </NavItem>
         </NavRight>
       </StyledHeader>
@@ -99,11 +103,12 @@ Header.propTypes = {
 };
 
 const mapStateToProps = state => ({
+  menuStatus: state.menu.show,
   isLoggedIn: state.auth.isLoggedIn,
 });
 
 const mapDispatchToProps = dispatch => ({
-  actions: bindActionCreators({ showModal }, dispatch),
+  actions: bindActionCreators({ showModal, toggleMenu }, dispatch),
 });
 
 export default connect(

--- a/src/components/Loading.jsx
+++ b/src/components/Loading.jsx
@@ -1,0 +1,53 @@
+import React from 'react';
+import styled from 'styled-components';
+
+import { calculateRem, mobileWidth } from 'styles';
+import { name, tagline, orgName, loadingText } from 'helpers';
+import { white } from 'styles/colors';
+
+const Loading = () => (
+  <StyledLoading>
+    <Tagline>{tagline}</Tagline>
+    <Title>{name}</Title>
+    <Tagline>by {orgName}</Tagline>
+    <LoadingText>{loadingText}</LoadingText>
+  </StyledLoading>
+);
+
+const StyledLoading = styled.div`
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  height: 100%;
+  padding: ${calculateRem(14)};
+  background: ${white};
+  width: 100%;
+  max-width: ${calculateRem(mobileWidth)};
+  box-sizing: border-box;
+  text-align: center;
+  position: fixed;
+  left: 50%;
+  top: 0%;
+  overflow-y: auto;
+  transform: translateX(-50%);
+  z-index: 50;
+`;
+
+const Title = styled.div`
+  margin: 0 auto;
+  line-height: ${calculateRem(43)};
+  font-size: ${calculateRem(36)};
+`;
+
+const Tagline = styled.div`
+  margin: 0 auto;
+`;
+
+const LoadingText = styled.div`
+  margin: ${calculateRem(60)} auto;
+  line-height: ${calculateRem(29)};
+  font-size: ${calculateRem(25)};
+`;
+
+export default Loading;

--- a/src/components/Masonry.jsx
+++ b/src/components/Masonry.jsx
@@ -13,7 +13,8 @@ const StyledMasonry = styled.div`
   column-gap: ${calculateRem(11)};
   column-fill: balance;
   width: 100%;
-  margin: 0 0 ${calculateRem(60)};
+  margin-bottom: ${calculateRem(60)};
+  overflow: visible;
 `;
 
 Masonry.propTypes = {

--- a/src/components/MemeCard.jsx
+++ b/src/components/MemeCard.jsx
@@ -2,18 +2,17 @@ import React from 'react';
 import styled from 'styled-components';
 
 import { calculateRem } from 'styles';
-import { black } from 'styles/colors';
+import { dark } from 'styles/colors';
 
-const MemeCard = ({ src }) => {
-  return <Meme src={src} />;
+const MemeCard = ({ src, square }) => {
+  return <Meme src={src} square={square} />;
 };
 
 const Meme = styled.img`
   display: block;
   margin: 0 0 ${calculateRem(11)};
-  border-radius: ${calculateRem(7)};
-  box-shadow: ${calculateRem(2)} ${calculateRem(4)} ${calculateRem(8)} 0
-    ${black};
+  border-radius: ${({ square }) => (square ? 'none' : `${calculateRem(7)}`)};
+  box-shadow: ${calculateRem(2)} ${calculateRem(4)} ${calculateRem(4)} 0 ${dark};
   width: 100%;
 `;
 

--- a/src/components/Menu.jsx
+++ b/src/components/Menu.jsx
@@ -1,0 +1,77 @@
+import React, { Component } from 'react';
+import styled from 'styled-components';
+import { connect } from 'react-redux';
+
+import { calculateRem, mobileWidth } from 'styles';
+import { white, dark } from 'styles/colors';
+
+export class Menu extends Component {
+  handleClick = () => {};
+
+  isPage = page => {
+    const {
+      location: { pathname },
+    } = this.props;
+    return pathname.includes(page);
+  };
+
+  render() {
+    return (
+      <StyledMenu>
+        <MenuItem>
+          Meme created by
+          <Inlet>@username123</Inlet>
+        </MenuItem>
+        <MenuItem>
+          Meme wall created by
+          <Inlet>@username123</Inlet>
+        </MenuItem>
+        <MenuItem>Flag meme</MenuItem>
+        <MenuItem>Mute meme</MenuItem>
+        <MenuItem>Mute meme</MenuItem>
+        <MenuItem>Mute player</MenuItem>
+        <MenuItem>Add meme to wall</MenuItem>
+        <MenuItem>Invite player to wall</MenuItem>
+        <MenuItem>View player profile</MenuItem>
+        <MenuItem>View your profile</MenuItem>
+        <MenuItem>View rules of play</MenuItem>
+        <MenuItem>Log out</MenuItem>
+      </StyledMenu>
+    );
+  }
+}
+
+const StyledMenu = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  height: 100vh;
+  background: ${white};
+  position: fixed;
+  z-index: 5;
+  width: 100%;
+  max-width: ${calculateRem(mobileWidth)};
+  box-sizing: border-box;
+  left: 50%;
+  top: 0%;
+  transform: translateX(-50%);
+  padding: ${calculateRem(60)} ${calculateRem(40)};
+  font-size: ${calculateRem(15)};
+  line-height: ${calculateRem(23)};
+`;
+
+const MenuItem = styled.div`
+  cursor: pointer;
+  color: ${dark};
+  width: 100%;
+`;
+const Inlet = styled.div`
+  padding: 0 ${calculateRem(40)};
+  box-sizing: border-box;
+`;
+
+const mapStateToProps = state => ({
+  location: state.router.location,
+});
+
+export default connect(mapStateToProps)(Menu);

--- a/src/components/Menu.test.jsx
+++ b/src/components/Menu.test.jsx
@@ -1,0 +1,11 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+
+import { Menu } from 'components/Menu';
+
+describe('Testing the Menu component', () => {
+  it('renders without crashing', () => {
+    const wrapper = shallow(<Menu />);
+    expect(wrapper).toMatchSnapshot();
+  });
+});

--- a/src/components/Modal.jsx
+++ b/src/components/Modal.jsx
@@ -33,10 +33,10 @@ const StyledModal = styled.div`
   text-align: center;
   padding: ${calculateRem(14)};
   background: ${white};
-  position: fixed;
   height: 100%;
   width: 100%;
   max-width: ${calculateRem(mobileWidth)};
+  position: fixed;
   left: 50%;
   top: 0%;
   overflow-y: auto;

--- a/src/components/SelectImage.jsx
+++ b/src/components/SelectImage.jsx
@@ -5,6 +5,7 @@ import { connect } from 'react-redux';
 
 import { hideModal } from 'actions/modal';
 import { selectImage } from 'actions/image';
+import { startLoader, stopLoader } from 'actions/loading';
 import { calculateRem } from 'styles';
 import CropImage from 'components/CropImage';
 import Button from 'components/Button';
@@ -54,8 +55,11 @@ export class SelectImage extends Component {
   };
 
   onFileChange = async e => {
+    const { actions } = this.props;
     if (e.target.files && e.target.files.length > 0) {
+      actions.startLoader();
       const imageDataUrl = await readFile(e.target.files[0]);
+      actions.stopLoader();
       this.setState({
         imageUrl: imageDataUrl,
       });
@@ -134,7 +138,10 @@ const Label = styled.label`
 `;
 
 const mapDispatchToProps = dispatch => ({
-  actions: bindActionCreators({ hideModal, selectImage }, dispatch),
+  actions: bindActionCreators(
+    { hideModal, selectImage, startLoader, stopLoader },
+    dispatch
+  ),
 });
 
 export default connect(

--- a/src/components/SelectImage.test.jsx
+++ b/src/components/SelectImage.test.jsx
@@ -13,6 +13,8 @@ describe('Testing the SelectImage page component', () => {
     actions: {
       hideModal: mockFunction,
       selectImage: mockFunction,
+      startLoader: mockFunction,
+      stopLoader: mockFunction,
     },
   };
   it('renders without crashing', () => {

--- a/src/components/ShareButton.jsx
+++ b/src/components/ShareButton.jsx
@@ -15,11 +15,7 @@ export class ShareButton extends PureComponent {
 
   onClick = () => {
     const { REACT_APP_APP_URL } = process.env;
-    const {
-      network,
-      actions,
-      router: { location },
-    } = this.props;
+    const { network, actions, location } = this.props;
     const path = this.getPath(location.pathname);
     const url = `${REACT_APP_APP_URL}${path}`;
     const shareUrl = getShareLink(url, network);
@@ -47,7 +43,7 @@ const Button = styled.div`
 `;
 
 const mapStateToProps = state => ({
-  router: state.router,
+  location: state.router.location,
 });
 
 const mapDispatchToProps = dispatch => ({

--- a/src/components/ShareButton.test.jsx
+++ b/src/components/ShareButton.test.jsx
@@ -6,10 +6,8 @@ import { ShareButton } from 'components/ShareButton';
 const mockFunction = jest.fn();
 describe('Testing the ShareButton component', () => {
   const props = {
-    router: {
-      location: {
-        pathname: '/',
-      },
+    location: {
+      pathname: '/',
     },
     network: 'facebook',
     actions: {

--- a/src/components/__snapshots__/Header.test.jsx.snap
+++ b/src/components/__snapshots__/Header.test.jsx.snap
@@ -33,7 +33,9 @@ exports[`Testing the Header component renders without crashing 1`] = `
     <styled.div
       last={true}
     >
-      <ForwardRef />
+      <ForwardRef
+        onClick={[Function]}
+      />
     </styled.div>
   </Styled(styled.div)>
 </styled.header>

--- a/src/components/__snapshots__/Menu.test.jsx.snap
+++ b/src/components/__snapshots__/Menu.test.jsx.snap
@@ -1,0 +1,48 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Testing the Menu component renders without crashing 1`] = `
+<styled.div>
+  <styled.div>
+    Meme created by
+    <styled.div>
+      @username123
+    </styled.div>
+  </styled.div>
+  <styled.div>
+    Meme wall created by
+    <styled.div>
+      @username123
+    </styled.div>
+  </styled.div>
+  <styled.div>
+    Flag meme
+  </styled.div>
+  <styled.div>
+    Mute meme
+  </styled.div>
+  <styled.div>
+    Mute meme
+  </styled.div>
+  <styled.div>
+    Mute player
+  </styled.div>
+  <styled.div>
+    Add meme to wall
+  </styled.div>
+  <styled.div>
+    Invite player to wall
+  </styled.div>
+  <styled.div>
+    View player profile
+  </styled.div>
+  <styled.div>
+    View your profile
+  </styled.div>
+  <styled.div>
+    View rules of play
+  </styled.div>
+  <styled.div>
+    Log out
+  </styled.div>
+</styled.div>
+`;

--- a/src/constants/actionTypes.js
+++ b/src/constants/actionTypes.js
@@ -1,5 +1,8 @@
 export const SHOW_MODAL = 'SHOW_MODAL';
 export const HIDE_MODAL = 'HIDE_MODAL';
+export const IS_LOADING = 'IS_LOADING';
+export const IS_COMPLETE = 'IS_COMPLETE';
+export const TOGGLE_MENU = 'TOGGLE_MENU';
 export const USER_LOGGED_IN = 'USER_LOGGED_IN';
 export const LOG_OUT = 'LOG_OUT';
 export const SELECT_IMAGE = 'SELECT_IMAGE';

--- a/src/helpers/getShareLink.js
+++ b/src/helpers/getShareLink.js
@@ -1,10 +1,10 @@
 /* eslint-disable no-unused-vars */
 import objectToGetParams from 'helpers/encodeQueryString';
+import { name, tagline } from 'helpers';
 
-const slogan = 'Make meaning. Share memes.';
 const text = {
-  single: `Check out this meme on memeing maker\n\n${slogan}`,
-  multiple: `Check out these memes on memeing maker\n\n${slogan}`,
+  single: `Check out this meme on ${name}\n\n${tagline}`,
+  multiple: `Check out these memes on ${name}\n\n${tagline}`,
 };
 
 const getShareLink = (url, network, contentType = 'single') => {

--- a/src/helpers/index.js
+++ b/src/helpers/index.js
@@ -11,3 +11,9 @@ export const camelize = string => {
   });
   return capitalized.join('');
 };
+
+// constants
+export const name = 'Memeing Maker';
+export const tagline = 'Make meaning. Share memes.';
+export const orgName = 'Limitless Harmony';
+export const loadingText = 'Meaning Loading...';

--- a/src/pages/CreateMeme.jsx
+++ b/src/pages/CreateMeme.jsx
@@ -11,6 +11,7 @@ import MemePreview from 'components/MemePreview';
 import { inputFill } from 'styles/colors';
 import { calculateRem } from 'styles';
 import { getFullImage, composeImage } from 'helpers/image';
+import { name } from 'helpers';
 import defaultImage from 'assets/images/dank.png';
 
 export class CreateMeme extends Component {
@@ -84,7 +85,7 @@ export class CreateMeme extends Component {
         />
         <ButtonContainer>
           Post to
-          <SubmitMeme onClick={this.composeMeme}>Memeing Maker</SubmitMeme>
+          <SubmitMeme onClick={this.composeMeme}>{name}</SubmitMeme>
           <GoArrow />
         </ButtonContainer>
       </Fragment>

--- a/src/pages/Featured.jsx
+++ b/src/pages/Featured.jsx
@@ -2,7 +2,6 @@ import React, { Component } from 'react';
 import styled from 'styled-components';
 
 import { calculateRem } from 'styles';
-import Masonry from 'components/Masonry';
 import MemeCard from 'components/MemeCard';
 import Button from 'components/Button';
 import meme from 'assets/memes/meme.png';
@@ -11,6 +10,7 @@ import meme2 from 'assets/memes/meme2.png';
 import meme3 from 'assets/memes/meme3.png';
 import meme4 from 'assets/memes/meme4.png';
 import { buttonBorder, black } from 'styles/colors';
+import { name, tagline } from 'helpers';
 
 class Featured extends Component {
   greet = () => {};
@@ -18,16 +18,26 @@ class Featured extends Component {
   render() {
     return (
       <StyledFeatured>
-        <Slogan>Make meaning. Share meaning.</Slogan>
-        <Title>Memeing Maker</Title>
+        <Tagline>{tagline}</Tagline>
+        <Title>{name}</Title>
         <SectionHeading>This Week’s Featured Memes</SectionHeading>
-        <Masonry>
-          <MemeCard src={meme} />
-          <MemeCard src={meme1} />
-          <MemeCard src={meme2} />
-          <MemeCard src={meme3} />
-          <MemeCard src={meme4} />
-        </Masonry>
+        <Container>
+          <Meme>
+            <MemeCard src={meme} />
+          </Meme>
+          <Meme>
+            <MemeCard src={meme1} />
+          </Meme>
+          <Meme>
+            <MemeCard src={meme2} />
+          </Meme>
+          <Meme>
+            <MemeCard src={meme3} />
+          </Meme>
+          <Meme>
+            <MemeCard src={meme4} />
+          </Meme>
+        </Container>
         <Button color={buttonBorder} outline rounded>
           <ButtonText>More</ButtonText>
         </Button>
@@ -46,16 +56,30 @@ const StyledFeatured = styled.div`
   text-align: center;
 `;
 
-export const Title = styled.div`
+const Container = styled.div`
+  margin: ${calculateRem(10)} auto ${calculateRem(40)};
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: space-between;
+  width: 100%;
+  text-align: center;
+`;
+
+const Meme = styled.div`
+  width: 48.5%;
+`;
+
+const Title = styled.div`
   margin: 0 auto ${calculateRem(60)};
   line-height: ${calculateRem(43)};
   font-size: ${calculateRem(36)};
 `;
 
-export const Slogan = styled.div`
+const Tagline = styled.div`
   margin: 0 auto;
 `;
-export const SectionHeading = styled.div`
+
+const SectionHeading = styled.div`
   font-size: ${calculateRem(18)};
   margin: ${calculateRem(16)} auto;
 `;

--- a/src/pages/Single.jsx
+++ b/src/pages/Single.jsx
@@ -1,0 +1,50 @@
+import React from 'react';
+import meme from 'assets/memes/meme.png';
+import styled from 'styled-components';
+
+import { calculateRem } from 'styles';
+import MemeCard from 'components/MemeCard';
+import { ThanksReaction } from 'components/Icons';
+import { black } from 'styles/colors';
+
+const Single = () => (
+  <Container>
+    <MemeCard square src={meme} />
+    <ReactionContainer>
+      <ThanksReaction />
+    </ReactionContainer>
+    <ReactionCount>200</ReactionCount>
+  </Container>
+);
+
+const Container = styled.div`
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  margin: ${calculateRem(18)} auto ${calculateRem(40)};
+  width: 100%;
+`;
+
+const ReactionContainer = styled.div`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  margin: ${calculateRem(6)} ${calculateRem(10)};
+  border: 2px solid ${black};
+  border-radius: 50%;
+  box-sizing: border-box;
+  width: ${calculateRem(53)};
+  height: ${calculateRem(53)};
+
+  svg,
+  img {
+    display: block;
+  }
+`;
+const ReactionCount = styled.div`
+  font-size: ${calculateRem(11)};
+  line-height: ${calculateRem(13)};
+`;
+
+export default Single;

--- a/src/pages/Single.jsx
+++ b/src/pages/Single.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import meme from 'assets/memes/meme.png';
+import meme2 from 'assets/memes/meme2.png';
 import styled from 'styled-components';
 
 import { calculateRem } from 'styles';
@@ -9,7 +9,7 @@ import { black } from 'styles/colors';
 
 const Single = () => (
   <Container>
-    <MemeCard square src={meme} />
+    <MemeCard square src={meme2} />
     <ReactionContainer>
       <ThanksReaction />
     </ReactionContainer>

--- a/src/pages/__snapshots__/Featured.test.jsx.snap
+++ b/src/pages/__snapshots__/Featured.test.jsx.snap
@@ -3,7 +3,7 @@
 exports[`Testing the Featured page component renders without crashing 1`] = `
 <styled.div>
   <styled.div>
-    Make meaning. Share meaning.
+    Make meaning. Share memes.
   </styled.div>
   <styled.div>
     Memeing Maker
@@ -11,23 +11,33 @@ exports[`Testing the Featured page component renders without crashing 1`] = `
   <styled.div>
     This Week’s Featured Memes
   </styled.div>
-  <Masonry>
-    <MemeCard
-      src="meme.png"
-    />
-    <MemeCard
-      src="meme1.png"
-    />
-    <MemeCard
-      src="meme2.png"
-    />
-    <MemeCard
-      src="meme3.png"
-    />
-    <MemeCard
-      src="meme4.png"
-    />
-  </Masonry>
+  <styled.div>
+    <styled.div>
+      <MemeCard
+        src="meme.png"
+      />
+    </styled.div>
+    <styled.div>
+      <MemeCard
+        src="meme1.png"
+      />
+    </styled.div>
+    <styled.div>
+      <MemeCard
+        src="meme2.png"
+      />
+    </styled.div>
+    <styled.div>
+      <MemeCard
+        src="meme3.png"
+      />
+    </styled.div>
+    <styled.div>
+      <MemeCard
+        src="meme4.png"
+      />
+    </styled.div>
+  </styled.div>
   <Button
     color="#979797"
     outline={true}

--- a/src/reducers/auth.js
+++ b/src/reducers/auth.js
@@ -1,4 +1,4 @@
-import { USER_LOGGED_IN, LOG_OUT } from 'shared/constants/actionTypes';
+import { USER_LOGGED_IN, LOG_OUT } from 'constants/actionTypes';
 
 const initialState = {
   isLoggedIn: true,

--- a/src/reducers/auth.test.js
+++ b/src/reducers/auth.test.js
@@ -1,6 +1,6 @@
 // Modules
 import authReducer from 'reducers/auth';
-import { USER_LOGGED_IN, LOG_OUT } from 'shared/constants/actionTypes';
+import { USER_LOGGED_IN, LOG_OUT } from 'constants/actionTypes';
 
 describe('auth reducer', () => {
   const initialState = {

--- a/src/reducers/image.js
+++ b/src/reducers/image.js
@@ -1,4 +1,4 @@
-import { REMOVE_IMAGE, SELECT_IMAGE } from 'shared/constants/actionTypes';
+import { REMOVE_IMAGE, SELECT_IMAGE } from 'constants/actionTypes';
 import defaultImage from 'assets/images/dank.png';
 
 const initialState = {

--- a/src/reducers/image.test.js
+++ b/src/reducers/image.test.js
@@ -1,6 +1,6 @@
 // Modules
 import imageReducer from 'reducers/image';
-import { REMOVE_IMAGE, SELECT_IMAGE } from 'shared/constants/actionTypes';
+import { REMOVE_IMAGE, SELECT_IMAGE } from 'constants/actionTypes';
 
 describe('modal reducer', () => {
   const initialState = {

--- a/src/reducers/index.js
+++ b/src/reducers/index.js
@@ -2,15 +2,19 @@ import { combineReducers } from 'redux';
 import { connectRouter } from 'connected-react-router';
 
 import modal from 'reducers/modal';
+import menu from 'reducers/menu';
 import auth from 'reducers/auth';
 import image from 'reducers/image';
+import loading from 'reducers/loading';
 
 const rootReducer = history =>
   combineReducers({
     router: connectRouter(history),
+    menu,
     modal,
     auth,
     image,
+    loading,
   });
 
 export default rootReducer;

--- a/src/reducers/loading.js
+++ b/src/reducers/loading.js
@@ -1,0 +1,20 @@
+import { IS_LOADING, IS_COMPLETE } from 'constants/actionTypes';
+
+const initialState = {
+  status: false,
+};
+
+const modal = (state = initialState, { type }) => {
+  switch (type) {
+    case IS_LOADING:
+      return { status: true };
+
+    case IS_COMPLETE:
+      return { status: false };
+
+    default:
+      return state;
+  }
+};
+
+export default modal;

--- a/src/reducers/menu.js
+++ b/src/reducers/menu.js
@@ -1,0 +1,19 @@
+import { TOGGLE_MENU } from 'constants/actionTypes';
+
+const initialState = {
+  show: false,
+};
+
+const menu = (state = initialState, { type, status }) => {
+  switch (type) {
+    case TOGGLE_MENU:
+      return {
+        ...state,
+        show: status,
+      };
+    default:
+      return state;
+  }
+};
+
+export default menu;

--- a/src/reducers/modal.js
+++ b/src/reducers/modal.js
@@ -1,4 +1,4 @@
-import { SHOW_MODAL, HIDE_MODAL } from 'shared/constants/actionTypes';
+import { SHOW_MODAL, HIDE_MODAL } from 'constants/actionTypes';
 
 const initialState = {
   id: '',

--- a/src/reducers/modal.test.js
+++ b/src/reducers/modal.test.js
@@ -1,6 +1,6 @@
 // Modules
 import modalReducer from 'reducers/modal';
-import { SHOW_MODAL, HIDE_MODAL } from 'shared/constants/actionTypes';
+import { SHOW_MODAL, HIDE_MODAL } from 'constants/actionTypes';
 
 describe('modal reducer', () => {
   const initialState = {

--- a/src/routes/Auth.jsx
+++ b/src/routes/Auth.jsx
@@ -2,12 +2,14 @@ import React from 'react';
 import { Switch, Route } from 'react-router-dom';
 
 import CreateRoute from 'pages/CreateMeme';
+import SingleMeme from 'pages/Single';
 
 const AuthRoutes = () => {
   return (
     <React.Fragment>
       <Switch>
         <Route exact path="/create" component={CreateRoute} />
+        <Route exact path="/memes/:id" component={SingleMeme} />
       </Switch>
     </React.Fragment>
   );

--- a/src/routes/index.jsx
+++ b/src/routes/index.jsx
@@ -10,12 +10,16 @@ import Authentication from 'components/Authentication';
 import RootModal from 'components/Modal';
 import SelectImageModal from 'components/SelectImage';
 import ShareModal from 'components/Share';
+import OverlayMenu from 'components/Menu';
+import Loading from 'components/Loading';
 
-const Routes = ({ showModal, modalId }) => {
+const Routes = ({ loading, showMenu, showModal, modalId }) => {
   return (
     <React.Fragment>
       <GlobalStyles />
       <Navbar />
+      {showMenu && <OverlayMenu />}
+      {loading && <Loading />}
       <Switch>
         <Route exact path="/" component={Featured} />
         <Route component={AuthRoutes} />
@@ -33,7 +37,9 @@ const Routes = ({ showModal, modalId }) => {
 
 const mapStateToProps = state => ({
   showModal: state.modal.show,
+  showMenu: state.menu.show,
   modalId: state.modal.id,
+  loading: state.loading.status,
 });
 
 export default connect(mapStateToProps)(Routes);

--- a/src/styles/colors.js
+++ b/src/styles/colors.js
@@ -2,6 +2,7 @@ import Color from 'color';
 
 export const black = '#000';
 export const darkGrey = '#0F0F0F';
+export const dark = '#4A4A4A';
 export const white = '#FFF';
 export const buttonBorder = '#979797';
 export const inputFill = '#F4F4F4';

--- a/yarn.lock
+++ b/yarn.lock
@@ -1917,7 +1917,7 @@ babel-register@^6.26.0:
     mkdirp "^0.5.1"
     source-map-support "^0.4.15"
 
-babel-runtime@^6.22.0, babel-runtime@^6.26.0, babel-runtime@^6.6.1:
+babel-runtime@^6.22.0, babel-runtime@^6.26.0:
   version "6.26.0"
   resolved "https://registry.yarnpkg.com/babel-runtime/-/babel-runtime-6.26.0.tgz#965c7058668e82b55d7bfe04ff2337bc8b5647fe"
   integrity sha1-llxwWGaOgrVde/4E/yM3vItWR/4=
@@ -2488,11 +2488,6 @@ class-utils@^0.3.5:
     define-property "^0.2.5"
     isobject "^3.0.0"
     static-extend "^0.1.1"
-
-classnames@^2.2.5:
-  version "2.2.6"
-  resolved "https://registry.yarnpkg.com/classnames/-/classnames-2.2.6.tgz#43935bffdd291f326dad0a205309b38d00f650ce"
-  integrity sha512-JR/iSQOSt+LQIWwrwEzJ9uk0xfN3mTVYMwt1Ir5mUcSN6pU+V4zQFFaJsclJbPuAUQH+yfWef6tm7l1quW3C8Q==
 
 clean-css@4.2.x:
   version "4.2.1"
@@ -3174,7 +3169,7 @@ date-now@^0.1.4:
   resolved "https://registry.yarnpkg.com/date-now/-/date-now-0.1.4.tgz#eaf439fd4d4848ad74e5cc7dbef200672b9e345b"
   integrity sha1-6vQ5/U1ISK105cx9vvIAZyueNFs=
 
-debug@2.6.9, debug@^2.1.2, debug@^2.1.3, debug@^2.2.0, debug@^2.3.3, debug@^2.6.0, debug@^2.6.8, debug@^2.6.9:
+debug@2.6.9, debug@^2.1.2, debug@^2.2.0, debug@^2.3.3, debug@^2.6.0, debug@^2.6.8, debug@^2.6.9:
   version "2.6.9"
   resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.9.tgz#5d128515df134ff327e90a4c93f4e077a536341f"
   integrity sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==
@@ -6249,13 +6244,6 @@ jsonify@~0.0.0:
   resolved "https://registry.yarnpkg.com/jsonify/-/jsonify-0.0.0.tgz#2c74b6ee41d93ca51b7b5aaee8f503631d252a73"
   integrity sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM=
 
-jsonp@^0.2.1:
-  version "0.2.1"
-  resolved "https://registry.yarnpkg.com/jsonp/-/jsonp-0.2.1.tgz#a65b4fa0f10bda719a05441ea7b94c55f3e15bae"
-  integrity sha1-pltPoPEL2nGaBUQep7lMVfPhW64=
-  dependencies:
-    debug "^2.1.3"
-
 jsprim@^1.2.2:
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/jsprim/-/jsprim-1.4.1.tgz#313e66bc1e5cc06e438bc1b7499c2e5c56acb6a2"
@@ -8396,7 +8384,7 @@ prompts@^0.1.9:
     kleur "^2.0.1"
     sisteransi "^0.1.1"
 
-prop-types@^15.5.4, prop-types@^15.5.8, prop-types@^15.6.1, prop-types@^15.6.2, prop-types@^15.7.2:
+prop-types@^15.5.4, prop-types@^15.6.1, prop-types@^15.6.2, prop-types@^15.7.2:
   version "15.7.2"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.7.2.tgz#52c41e75b8c87e72b9d9360e0206b99dcbffa6c5"
   integrity sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==
@@ -8771,16 +8759,6 @@ react-scripts@2.1.8:
     workbox-webpack-plugin "3.6.3"
   optionalDependencies:
     fsevents "1.2.4"
-
-react-share@^2.4.0:
-  version "2.4.0"
-  resolved "https://registry.yarnpkg.com/react-share/-/react-share-2.4.0.tgz#e033316760cfe3265bf0cb031373a7564dbf92f5"
-  integrity sha512-PlVs9Z0/ma0LDaVOPC9uWEysucoL2OOnBEFu7m4TjFMiS42KmHDTW9k9L4LOCCpxiHemfrg/EkzHuU2YXJHn8g==
-  dependencies:
-    babel-runtime "^6.6.1"
-    classnames "^2.2.5"
-    jsonp "^0.2.1"
-    prop-types "^15.5.8"
 
 react-side-effect@^1.1.0:
   version "1.1.5"


### PR DESCRIPTION
#### What does this PR do?

Adds design for single meme view, loading view, overlay menu, and some refactoring

#### How should this be manually tested?

- checkout the branch `git checkout overlay-menu-design `
- install dependencies `yarn`
- start the application `yarn start`
- visit `localhost:3000`
- visit `localhost:3000/memes/1`
- To see the loading page, go into `src/reducers/loading.js` and set status in `initialState` to `true`

#### Any background context you want to provide?

N/A

#### Screenshots (if appropriate)
<img width="1440" alt="Screen Shot 2019-04-06 at 11 15 49 AM" src="https://user-images.githubusercontent.com/26969309/55759281-d80b1800-5a50-11e9-8540-b8b1e021463b.png">
<img width="1440" alt="Screen Shot 2019-04-08 at 10 42 48 PM" src="https://user-images.githubusercontent.com/26969309/55759282-d8a3ae80-5a50-11e9-8143-1bb52a06921b.png">
<img width="1440" alt="Screen Shot 2019-04-08 at 10 53 34 PM" src="https://user-images.githubusercontent.com/26969309/55759415-346e3780-5a51-11e9-9d54-ed28a8176ea0.png">


#### Note
